### PR TITLE
TASK: Use keyValue for variable when updating ServerConfiguration

### DIFF
--- a/Classes/Command/OAuthServerCommandController.php
+++ b/Classes/Command/OAuthServerCommandController.php
@@ -72,7 +72,7 @@ final class OAuthServerCommandController extends CommandController
                 $this->serverConfigurationRepository->add(new ServerConfiguration($keyName, $keyValue));
                 $this->outputLine(sprintf('<success>Generated a new %s and stored it in the database.</success>', $keyName));
             } else {
-                $serverConfiguration->setConfigurationValue($keyName);
+                $serverConfiguration->setConfigurationValue($keyValue);
                 $this->serverConfigurationRepository->update($serverConfiguration);
                 $this->outputLine(sprintf('<success>Updated %s and stored it in the database.</success>', $keyName));
             }


### PR DESCRIPTION
The `$keyName` variable is used for setting value - instead the `$keyValue` should be used

Solves #11 